### PR TITLE
Pandas DataFrame append is deprecated 

### DIFF
--- a/code/optimize_mutation_matrix.py
+++ b/code/optimize_mutation_matrix.py
@@ -149,7 +149,7 @@ def calculate_C(c, sigmas, DPs, BC):
         print(child)
         d = pd.DataFrame([[desc_scores(desc[a]) for a in mixed_muts]], columns = mixed_muts,\
             index = ['ANC:{}'.format(child)])
-        C = C.append(d)
+        C = pd.concat([C,d])
 
         
     #C = C.reset_index(drop = True)


### PR DESCRIPTION
pandas.DataFrame.append is deprecated since Pandas 1.40. The new paradigm for appending two DataFrames is using pandas.concat.